### PR TITLE
Add ability to specify where the menu is appended

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ var options = {
     // css classes that context menu will have
     contextMenuClasses: [
       // add class names to this list
-    ]
+    ],
+    // if needed, provide an alternate css selector of
+    // the element to which the menu's DOM element should be appended
+    componentParentSelector: 'body'
 };
 ```
 

--- a/cytoscape-context-menus.js
+++ b/cytoscape-context-menus.js
@@ -37,12 +37,9 @@
       // css classes that context menu will have
       contextMenuClasses: [
         // add class names to this list
-      ],
-      // if needed, provide an alternate css selector of
-      // the element to which the menu's DOM element should be appended
-      componentParentSelector: 'body'
+      ]
     };
-    
+
     var options;
     var $cxtMenu;
     var menuItemCSSClass = 'cy-context-menus-cxt-menuitem';
@@ -171,7 +168,7 @@
         hideMenuItemComponents();
         cy.scratch('cxtMenuPosition', event.cyPosition);
         
-        var containerPos = $(cy.container()).position();
+        var containerPos = $(cy.container()).offset();
 
         var left = containerPos.left + event.cyRenderedPosition.x;
         var top = containerPos.top + event.cyRenderedPosition.y;
@@ -209,7 +206,7 @@
       var classes = getClassStr(options.contextMenuClasses);
       $cxtMenu = $('<div id="cy-context-menus-cxt-menu" class=' + classes + '></div>');
       
-      $(options.componentParentSelector).append($cxtMenu);
+      $('body').append($cxtMenu);
       return $cxtMenu;
     }
     

--- a/cytoscape-context-menus.js
+++ b/cytoscape-context-menus.js
@@ -37,7 +37,10 @@
       // css classes that context menu will have
       contextMenuClasses: [
         // add class names to this list
-      ]
+      ],
+      // if needed, provide an alternate css selector of
+      // the element to which the menu's DOM element should be appended
+      componentParentSelector: 'body'
     };
     
     var options;
@@ -205,8 +208,8 @@
     function createAndAppendCxtMenuComponent() {
       var classes = getClassStr(options.contextMenuClasses);
       $cxtMenu = $('<div id="cy-context-menus-cxt-menu" class=' + classes + '></div>');
-      $('body').append($cxtMenu);
       
+      $(options.componentParentSelector).append($cxtMenu);
       return $cxtMenu;
     }
     


### PR DESCRIPTION
Currently the context menu DOM element (#cy-context-menus-cxt-menu) is
appended to the document's body element.

When the menu is positioned at the time of the user's click, the "left"
and "right" positions are calculated based on the rendered graph's
container's location plus the cilck position within the graph.

If the graph was rendered in a container which was moved away from the
normal flow position in the body (such as for the purpose of containing
it in a "slide- in" animation), then the calculated position for the
context menu might not be correct based on the current positioning of
elements in the browser.

To accommodate this, add an option that allows for supplying a CSS
selector that the #cy-context-menus-cxt-menu element should be appended
to instead of the body.