### PR TITLE
Add option to append context menu to a specific element

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ var options = {
     // css classes that context menu will have
     contextMenuClasses: [
       // add class names to this list
-    ]
+    ],
+    container: 'body' // string selector or element to which context menu should be appended
 };
 ```
 

--- a/cytoscape-context-menus.js
+++ b/cytoscape-context-menus.js
@@ -199,17 +199,15 @@
       function adjustCxtMenu(event) {
         var currentCxtMenuPosition = getScratchProp('cxtMenuPosition');
         var cyPos = event.position || event.cyPosition;
+        var left, top, containerPos, renderedPos;
 
         if( currentCxtMenuPosition != cyPos ) {
           hideMenuItemComponents();
           setScratchProp('anyVisibleChild', false);// we hide all children there is no visible child remaining
           setScratchProp('cxtMenuPosition', cyPos);
 
-          var containerPos = $(cy.container()).offset();
-          var renderedPos = event.renderedPosition || event.cyRenderedPosition;
-
-          var left = containerPos.left + renderedPos.x;
-          var top = containerPos.top + renderedPos.y;
+		  
+            left = renderedPos.x;
 
           $cxtMenu.css('left', left);
           $cxtMenu.css('top', top);

--- a/cytoscape-context-menus.js
+++ b/cytoscape-context-menus.js
@@ -38,7 +38,8 @@
       // css classes that context menu will have
       contextMenuClasses: [
         // add class names to this list
-      ]
+      ],
+      container: 'body' // string selector or element to which context menu should be appended
     };
     
     var eventCyTapStart; // The event to be binded on tap start
@@ -245,8 +246,7 @@
         $cxtMenu.addClass('cy-context-menus-cxt-menu');
         setScratchProp('cxtMenu', $cxtMenu);
 
-        $('body').append($cxtMenu);
-        return $cxtMenu;
+        return $cxtMenu.appendTo(options.container);
       }
 
       // Creates a menu item as an html component

--- a/cytoscape-context-menus.js
+++ b/cytoscape-context-menus.js
@@ -206,8 +206,18 @@
           setScratchProp('anyVisibleChild', false);// we hide all children there is no visible child remaining
           setScratchProp('cxtMenuPosition', cyPos);
 
+          renderedPos = event.renderedPosition || event.cyRenderedPosition;
 		  
+          if(opts.container) {
+            // append inside container
             left = renderedPos.x;
+            top = renderedPos.y;
+          } else {
+            // append to body, thus adding container offset
+            containerPos = $(cy.container()).offset();
+            left = containerPos.left + renderedPos.x;
+            top = containerPos.top + renderedPos.y;
+          }
 
           $cxtMenu.css('left', left);
           $cxtMenu.css('top', top);


### PR DESCRIPTION
I would like to add an option to the plugin which will allow appending context menu to a specific element. By default, it will be `body` (just as it is now). 

I'm using the plugin within Angular and I don't want to include cytoscape.js-context-menus CSS in the global stylesheet. Instead, I would like to add it on a component level. Additionally, such an option exists also for instance in bootstrap tooltips. 