### PR TITLE
Revert "fixed #17 context menu repositions if off screen to the right or bottom"

### DIFF
--- a/cytoscape-context-menus.js
+++ b/cytoscape-context-menus.js
@@ -199,9 +199,7 @@
         var currentCxtMenuPosition = getScratchProp('cxtMenuPosition');
         var cyPos = event.position || event.cyPosition;
 
-        if (currentCxtMenuPosition != cyPos) {
-          var cxtMenuWidth = $cxtMenu.width();
-          var cxtMenuHeight = $cxtMenu.height();
+        if( currentCxtMenuPosition != cyPos ) {
           hideMenuItemComponents();
           setScratchProp('anyVisibleChild', false);// we hide all children there is no visible child remaining
           setScratchProp('cxtMenuPosition', cyPos);
@@ -211,16 +209,6 @@
 
           var left = containerPos.left + renderedPos.x;
           var top = containerPos.top + renderedPos.y;
-          
-          var windowHeight = window.innerHeight;
-          var windowWidth = window.innerWidth;
-          if (left + cxtMenuWidth > windowWidth) {
-            left = left - cxtMenuWidth;
-          }
-
-          if (top + cxtMenuHeight > windowHeight) {
-            top = top - cxtMenuHeight
-          }
 
           $cxtMenu.css('left', left);
           $cxtMenu.css('top', top);


### PR DESCRIPTION
Reverts iVis-at-Bilkent/cytoscape.js-context-menus#19 due to a bug