### PR TITLE
Add option for taphold

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Plain HTML/JS has the extension registered for you automatically, because no `re
 ## Default Options
 ```js
 var options = {
-    // Show menu on taphold
+    // Show menu on taphold in stead of right-mouse click
     taphold: false,
     // List of initial menu items
     menuItems: [/*
@@ -125,8 +125,6 @@ An instance has a number of functions available:
 
 ```js
 instance.isActive(); // Returns whether the extension is active.
-
-instance.setTaphold(boolean); // Show menu on taphold (true), or ignore taphold (false) 
 
 instance.appendMenuItem(item); // Appends given menu item to the menu items list.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Cytoscape.js extension to provide context menu around elements and core instan
 
 ## Demo
 
-Click [here](https://raw.githack.com/iVis-at-Bilkent/cytoscape.js-context-menus/unstable/demo.html) (simple) or [here](https://raw.githack.com/iVis-at-Bilkent/cytoscape.js-context-menus/unstable/demo-customized.html) (customized) or [here](https://raw.githack.com/iVis-at-Bilkent/cytoscape.js-context-menus/unstable/demo-show-hide-menuitem.html) (with different menu items) for demos
+Click [here](https://ivis-at-bilkent.github.io/cytoscape.js-context-menus/demo.html) (simple) or [here](https://ivis-at-bilkent.github.io/cytoscape.js-context-menus/demo-customized.html) (customized) or [here](https://ivis-at-bilkent.github.io/cytoscape.js-context-menus/demo-show-hide-menuitem.html) (with different menu items) for demos
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Plain HTML/JS has the extension registered for you automatically, because no `re
 ## Default Options
 ```js
 var options = {
+    // Show menu on taphold
+    taphold: false,
     // List of initial menu items
     menuItems: [/*
       {
@@ -123,6 +125,8 @@ An instance has a number of functions available:
 
 ```js
 instance.isActive(); // Returns whether the extension is active.
+
+instance.setTaphold(boolean); // Show menu on taphold (true), or ignore taphold (false) 
 
 instance.appendMenuItem(item); // Appends given menu item to the menu items list.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,21 @@ Download the library:
  * via bower: `bower install cytoscape-context-menus`, or
  * via direct download in the repository (probably from a tag).
 
-`require()` the library as appropriate for your project:
+Import the library as appropriate for your project:
+
+ES import:
+
+```js
+import cytoscape from 'cytoscape';
+import $ from 'jquery';
+import contextMenus from 'cytoscape-context-menus';
+
+// register extension
+cytoscape.use(contextMenus, $);
+
+// import CSS as well
+import 'cytoscape-context-menus/cytoscape-context-menus.css';
+```
 
 CommonJS:
 ```js

--- a/cytoscape-context-menus.js
+++ b/cytoscape-context-menus.js
@@ -160,18 +160,10 @@
 
         var cxtfcn;
         var cxtCoreFcn;
-
+        var evtType=options.taphold?'taphold':'cxttap'
         if(coreAsWell) {
-          cy.on('cxttap', cxtCoreFcn = function(event) {
-            var target = event.target || event.cyTarget;
-            if( target != cy ) {
-              return;
-            }
-
-            _cxtfcn(event);
-          });
-          cy.on('taphold', cxtCoreFcn = function(event) {
-            if (!options.taphold) return
+          
+          cy.on(evtType, cxtCoreFcn = function(event) {
             var target = event.target || event.cyTarget;
             if( target != cy ) {
               return;
@@ -182,11 +174,7 @@
         }
 
         if(selector) {
-          cy.on('cxttap', selector, cxtfcn = function(event) {
-            _cxtfcn(event);
-          });
-          cy.on('taphold', selector, cxtfcn = function(event) {
-            if (!options.taphold) return
+          cy.on(evtType, selector, cxtfcn = function(event) {
             _cxtfcn(event);
           });
         }
@@ -376,12 +364,14 @@
         var selector = $component.data('selector');
         var callOnClickFcn = $component.data('call-on-click-function');
         var cxtCoreFcn = $component.data('cy-context-menus-cxtcorefcn');
-
+       
         if(cxtfcn) {
+          cy.off('taphold', selector, cxtfcn);
           cy.off('cxttap', selector, cxtfcn);
         }
 
         if(cxtCoreFcn) {
+          cy.off('taphold', cxtCoreFcn);
           cy.off('cxttap', cxtCoreFcn);
         }
 
@@ -434,9 +424,6 @@
           // Returns whether the extension is active
          isActive: function() {
            return getScratchProp('active');
-         },
-         setTaphold: function(value) {
-          options.taphold=value
          },
          // Appends given menu item to the menu items list.
          appendMenuItem: function(item) {

--- a/cytoscape-context-menus.js
+++ b/cytoscape-context-menus.js
@@ -7,6 +7,8 @@
     if( !cytoscape ){ return; } // can't register if cytoscape unspecified
     
     var defaults = {
+      // Use taphold to bring up the context menu
+      taphold: false,
       // List of initial menu items
       menuItems: [
         /*
@@ -168,10 +170,23 @@
 
             _cxtfcn(event);
           });
+          cy.on('taphold', cxtCoreFcn = function(event) {
+            if (!options.taphold) return
+            var target = event.target || event.cyTarget;
+            if( target != cy ) {
+              return;
+            }
+
+            _cxtfcn(event);
+          });
         }
 
         if(selector) {
           cy.on('cxttap', selector, cxtfcn = function(event) {
+            _cxtfcn(event);
+          });
+          cy.on('taphold', selector, cxtfcn = function(event) {
+            if (!options.taphold) return
             _cxtfcn(event);
           });
         }
@@ -419,6 +434,9 @@
           // Returns whether the extension is active
          isActive: function() {
            return getScratchProp('active');
+         },
+         setTaphold: function(value) {
+          options.taphold=value
          },
          // Appends given menu item to the menu items list.
          appendMenuItem: function(item) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cytoscape-context-menus",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "A Cytoscape.js extension to provide context menu around elements and core instance.",
   "main": "cytoscape-context-menus.js",
   "style": "cytoscape-context-menus.css",


### PR DESCRIPTION
Two fingers on touchscreen to bring up the context menu is tricky and does not work well on all kinds of screens. With taphold option it is much easier on touchscreen