### PR TITLE
Fix documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ var options = {
         disabled: false, // Whether the item will be created as disabled
         show: false, // Whether the item will be shown or not
         hasTrailingDivider: true, // Whether the item will have a trailing divider
-        coreAsWell: false // Whether core instance have this item on cxttap
+        coreAsWell: false, // Whether core instance have this item on cxttap
         submenu: [] // Shows the listed menuItems as a submenu for this item. An item must have either submenu or onClickFunction or both.
       },
       {


### PR DESCRIPTION
README.md includes the default `options` object the extension uses. However, there is a syntax error inside it.